### PR TITLE
fixing dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "prettier": "^2.2.0",
     "typedoc": "^0.19.2",
     "typedoc-plugin-no-inherit": "^1.2.0",
-    "typescript": "^4.1.2"
+    "typescript": "^4.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,50 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "lib": [
+      "DOM",
+      "ES2018"
+    ] /* Specify library files to be included in the compilation. */,
+    "declaration": false /* Generates corresponding '.d.ts' file. */,
+    "noEmit": true,
+    "removeComments": true /* Do not emit comments to output. */,
+    "resolveJsonModule": true /* Allows importing modules with a ‘.json’ extension */,
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    // "strictNullChecks": true /* Enable strict null checks. */,
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+
+    /* Module Resolution Options */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+
+    /* Experimental Options */
+    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  },
+  "typedocOptions": {
+    "includes": "./source/services/",
+    "exclude": ["**/*+(.d.ts|.test.ts|node_modules)"],
+    "mode": "modules",
+    "externalPattern": ["**/resources/**", "**/deployment/**"],
+    "excludeExternals": true,
+    "ignoreCompilerErrors": true,
+    "out": "docs",
+    "includeVersion": true,
+    "readMe": "./README.md"
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-centralized-logging/issues/31

*Description of changes:*
* fixing typedoc typescript dependency in package.json
```
npm ERR! While resolving: aws-centralized-logging@4.0.0
npm ERR! Found: typescript@4.2.4
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"^4.1.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer typescript@"3.9.x || 4.0.x" from typedoc@0.19.2
npm ERR! node_modules/typedoc
npm ERR!   dev typedoc@"^0.19.2" from the root project
npm ERR! 
```
* adding tsconfig.json at root of the project for typedoc doc generation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
