### PR TITLE
update path building for HelperLambda CLTransformer to remain relativ…

### DIFF
--- a/source/resources/lib/cl-primary-stack.ts
+++ b/source/resources/lib/cl-primary-stack.ts
@@ -91,6 +91,7 @@ import { Queue, QueueEncryption } from "@aws-cdk/aws-sqs";
 import { Topic } from "@aws-cdk/aws-sns";
 import { Alias, IAlias } from "@aws-cdk/aws-kms";
 import { EmailSubscription } from "@aws-cdk/aws-sns-subscriptions";
+import path from 'path';
 
 enum LogLevel {
   ERROR = "error",
@@ -388,7 +389,12 @@ export class CLPrimary extends Stack {
         SEND_METRIC: metricsMap.findInMap("Metric", "SendAnonymousMetric"),
       },
       handler: "index.handler",
-      code: Code.fromAsset("../../source/services/helper/dist/cl-helper.zip"),
+      code: Code.fromAsset(
+        path.join(
+          __dirname, 
+          "../../services/helper/dist/cl-helper.zip"
+        )
+      ),
       runtime: Runtime.NODEJS_12_X,
       timeout: Duration.seconds(300),
       role: helperRole,
@@ -827,7 +833,10 @@ export class CLPrimary extends Stack {
       },
       handler: "index.handler",
       code: Code.fromAsset(
-        "../../source/services/transformer/dist/cl-transformer.zip"
+        path.join(
+          __dirname,
+          "../../services/transformer/dist/cl-transformer.zip"
+        )
       ),
       runtime: Runtime.NODEJS_12_X,
       timeout: Duration.seconds(300),


### PR DESCRIPTION
Re-opening previously closed PR

*Issue #, if available:* Please see https://github.com/awslabs/aws-centralized-logging/pull/32

*Description of changes:*
Update the way paths are being build from assets to consider the current directory instead of `process.cwd()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
